### PR TITLE
Fix the implementation of SystemDataModel.mixed

### DIFF
--- a/src/module/data/item/test.ts
+++ b/src/module/data/item/test.ts
@@ -2,7 +2,23 @@ import { SystemDataModel } from "@data/abstract.ts"
 import { ItemDataModel } from "./base.ts"
 import { BasicInformationTemplate } from "./templates/basic-information.ts"
 
-class TestSystemData extends SystemDataModel<TestSystemSchema> {}
+declare class TestSystemData extends SystemDataModel<TestSystemSchema> {
+	constructor(...args: any[])
+
+	static name: "foo"
+
+	static static1: 123
+	instance1: "foo"
+}
+
+declare class TestSystemData2 extends SystemDataModel<TestSystemSchema2> {
+	constructor(...args: any[])
+
+	static name: "bar"
+
+	protected static static2: 456
+	instance2: "bar"
+}
 
 export class TestItemData1 extends foundry.abstract.TypeDataModel<TestItemSchema, Item> {}
 
@@ -10,13 +26,31 @@ export class TestItemData2 extends SystemDataModel<TestItemSchema, Item> {}
 
 export class TestItemData3 extends ItemDataModel<TestItemSchema> {}
 
-export class TestItemData4 extends SystemDataModel.mixin<[typeof TestSystemData], TestItemSchema>(TestSystemData) {}
+export class TestItemData4 extends SystemDataModel.mixin(TestSystemData, TestSystemData2) {}
+TestItemData4.name
+//            ^ string
+// The given class names are intentionally completely ignored as they're immiscible
 
-export class TestItemData5 extends ItemDataModel.mixin<[typeof BasicInformationTemplate], TestItemSchema>(
-	BasicInformationTemplate,
-) {}
+TestItemData4.static1
+TestItemData4["static2"]
+
+const test = new TestItemData4()
+test.instance1
+test.instance2
+test.schemaProp1
+test.schemaProp2
+
+export class TestItemData5 extends ItemDataModel.mixin(BasicInformationTemplate) {}
 
 type TestItemSchema = {}
-type TestSystemSchema = {}
+
+import fields = foundry.data.fields
+type TestSystemSchema = {
+	schemaProp1: fields.NumberField
+}
+
+type TestSystemSchema2 = {
+	schemaProp2: fields.StringField
+}
 
 // export { TestItemData, type TestItemSchema }


### PR DESCRIPTION
Ends up being pretty svelte if you ask me. There are a few unfinished bits and bobs but with the removal of `_initializationOrder` as being immiscible (at least at the type level, you can leave it at runtime if you want) it vastly simplifies the correct logic here.

The main issue with the old approach as that at numerous points it turned the class into an object which strips visibility modifiers, the constructor, and so on. This new approach uses various approaches (admittedly hacks) in order to avoid doing that. Note that I chose a simpler version that won't deal with visibility modifiers _in immiscible properties._ They work elsewhere but it really bloated the code to work with visibility modifiers.